### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/83ae689a-842a-4463-b340-72e31bcd3b1c/d960eee9-0151-4994-81cb-c0f97ff88147/_apis/work/boardbadge/9cde8aeb-9086-4d02-b1d3-80f6299d9ede)](https://dev.azure.com/aiw-devops/83ae689a-842a-4463-b340-72e31bcd3b1c/_boards/board/t/d960eee9-0151-4994-81cb-c0f97ff88147/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1141](https://dev.azure.com/aiw-devops/83ae689a-842a-4463-b340-72e31bcd3b1c/_workitems/edit/1141). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.